### PR TITLE
Fix

### DIFF
--- a/freertos-rust-examples/examples/linux/main.rs
+++ b/freertos-rust-examples/examples/linux/main.rs
@@ -23,7 +23,7 @@ fn main() {
             let mut i = 0;
             loop {
                 println!("Hello from Task! {}", i);
-                CurrentTask::delay(Duration::ms(1000));
+                CurrentTask::delay(Duration::from_ms(1000));
                 i = i + 1;
             }
         })


### PR DESCRIPTION
```
cd freertos-rust-examples
$ cargo run --example linux
   Compiling freertos-rust v0.1.2 (/home/alex/git/veecle/FreeRTOS-rust/freertos-rust)
   Compiling freertos-rust-examples v0.1.1 (/home/alex/git/veecle/FreeRTOS-rust/freertos-rust-examples)
error: linking with `cc` failed: exit status: 1
  |
  = note: LC_ALL="C" PATH="/home/alex/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin:/home/alex/.local/bin:/home/alex/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/lib/wsl/lib:/mnt/c/Windows/system32:/mnt/c/Windows:/mnt/c/Windows/System32/Wbem:/mnt/c/Windows/System32/WindowsPowerShell/v1.0/:/mnt/c/Windows/System32/OpenSSH/:/mnt/c/Users/AlexCorcoles/AppData/Local/Microsoft/WindowsApps:/mnt/c/Program Files (x86)/Nmap" VSLANG="1033" "cc" "-m64" "/tmp/rustc8NyRVe/symbols.o" "/home/alex/git/veecle/FreeRTOS-rust/target/debug/examples/linux-6beb5e566f2bb0e5.12mhdh6nbcsmk3yb.rcgu.o" "/home/alex/git/veecle/FreeRTOS-rust/target/debug/examples/linux-6beb5e566f2bb0e5.1b93ezqc9p33plit.rcgu.o" "/home/alex/git/veecle/FreeRTOS-rust/target/debug/examples/linux-6beb5e566f2bb0e5.1g4p9yf4jkmdutpt.rcgu.o" "/home/alex/git/veecle/FreeRTOS-rust/target/debug/examples/linux-6beb5e566f2bb0e5.1nextwdozw3ywg1b.rcgu.o" "/home/alex/git/veecle/FreeRTOS-rust/target/debug/examples/linux-6beb5e566f2bb0e5.1ohk3lf3iz8tsxcs.rcgu.o" "/home/alex/git/veecle/FreeRTOS-rust/target/debug/examples/linux-6beb5e566f2bb0e5.2dysja9xecmm3wd1.rcgu.o" "/home/alex/git/veecle/FreeRTOS-rust/target/debug/examples/linux-6beb5e566f2bb0e5.2kv916od7yay3bdx.rcgu.o" "/home/alex/git/veecle/FreeRTOS-rust/target/debug/examples/linux-6beb5e566f2bb0e5.2pft1m3trodiaob5.rcgu.o" "/home/alex/git/veecle/FreeRTOS-rust/target/debug/examples/linux-6beb5e566f2bb0e5.38x8e2pwipl034kq.rcgu.o" "/home/alex/git/veecle/FreeRTOS-rust/target/debug/examples/linux-6beb5e566f2bb0e5.3pz67u3m7r68rsbb.rcgu.o" "/home/alex/git/veecle/FreeRTOS-rust/target/debug/examples/linux-6beb5e566f2bb0e5.495x5hvctwcn7a4.rcgu.o" "/home/alex/git/veecle/FreeRTOS-rust/target/debug/examples/linux-6beb5e566f2bb0e5.4fur9e6cyyvpvw8s.rcgu.o" "/home/alex/git/veecle/FreeRTOS-rust/target/debug/examples/linux-6beb5e566f2bb0e5.4gn93rxev36gyig3.rcgu.o" "/home/alex/git/veecle/FreeRTOS-rust/target/debug/examples/linux-6beb5e566f2bb0e5.4p1s02wckhftgjcn.rcgu.o" "/home/alex/git/veecle/FreeRTOS-rust/target/debug/examples/linux-6beb5e566f2bb0e5.54h2qzeyy8qy7c20.rcgu.o" "/home/alex/git/veecle/FreeRTOS-rust/target/debug/examples/linux-6beb5e566f2bb0e5.9qtkug2dyemakkr.rcgu.o" "/home/alex/git/veecle/FreeRTOS-rust/target/debug/examples/linux-6beb5e566f2bb0e5.bvbher99ubxek5y.rcgu.o" "/home/alex/git/veecle/FreeRTOS-rust/target/debug/examples/linux-6beb5e566f2bb0e5.oddnunhl5icgph1.rcgu.o" "/home/alex/git/veecle/FreeRTOS-rust/target/debug/examples/linux-6beb5e566f2bb0e5.rn3zdyeg6qq2dyv.rcgu.o" "/home/alex/git/veecle/FreeRTOS-rust/target/debug/examples/linux-6beb5e566f2bb0e5.19c3lbno1hkfcrs8.rcgu.o" "-Wl,--as-needed" "-L" "/home/alex/git/veecle/FreeRTOS-rust/target/debug/deps" "-L" "/home/alex/git/veecle/FreeRTOS-rust/target/debug/build/freertos-rust-examples-1b084d26ed3adbf1/out" "-L" "/home/alex/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-Wl,-Bstatic" "-lfreertos" "/home/alex/git/veecle/FreeRTOS-rust/target/debug/deps/libfreertos_rust-735dd7d96cfbebc4.rlib" "/home/alex/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd-d2ef02247056996e.rlib" "/home/alex/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libpanic_unwind-fde67f6c4eccaa42.rlib" "/home/alex/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libobject-2549d0ec992a5666.rlib" "/home/alex/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libmemchr-bb9bfc0931d5cad0.rlib" "/home/alex/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libaddr2line-7c0b91fdc4adc2c5.rlib" "/home/alex/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libgimli-6ec164769e6c2957.rlib" "/home/alex/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/librustc_demangle-95326caaef561554.rlib" "/home/alex/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd_detect-704dba0df3717bb7.rlib" "/home/alex/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libhashbrown-5f0117cb69112303.rlib" "/home/alex/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/librustc_std_workspace_alloc-7a95907f1ed0cea5.rlib" "/home/alex/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libminiz_oxide-d4aa666f8242aefc.rlib" "/home/alex/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libadler-9abec8861e966bc7.rlib" "/home/alex/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libunwind-863ac378b60eeb30.rlib" "/home/alex/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcfg_if-fc8aa5b7d220f0a9.rlib" "/home/alex/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/liblibc-0cc850f1e941238d.rlib" "/home/alex/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/liballoc-f7b445210e88e768.rlib" "/home/alex/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/librustc_std_workspace_core-f37052492751c579.rlib" "/home/alex/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcore-fd15ec7f305d48e7.rlib" "/home/alex/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcompiler_builtins-d700583125da6701.rlib" "-Wl,-Bdynamic" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-L" "/home/alex/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-o" "/home/alex/git/veecle/FreeRTOS-rust/target/debug/examples/linux-6beb5e566f2bb0e5" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-nodefaultlibs"
  = note: /usr/bin/ld: /home/alex/git/veecle/FreeRTOS-rust/target/debug/deps/libfreertos_rust-735dd7d96cfbebc4.rlib(freertos_rust-735dd7d96cfbebc4.1czvuvtbqu0jgxx5.rcgu.o): in function `freertos_rust::units::get_tick_period_ms':
          /home/alex/git/veecle/FreeRTOS-rust/freertos-rust/src/units.rs:7: undefined reference to `freertos_rs_get_portTICK_PERIOD_MS'
          /usr/bin/ld: /home/alex/git/veecle/FreeRTOS-rust/target/debug/deps/libfreertos_rust-735dd7d96cfbebc4.rlib(freertos_rust-735dd7d96cfbebc4.1hbzz7lkzbkykmz4.rcgu.o): in function `freertos_rust::task::Task::spawn_inner':
          /home/alex/git/veecle/FreeRTOS-rust/freertos-rust/src/task.rs:182: undefined reference to `freertos_rs_spawn_task'
          /usr/bin/ld: /home/alex/git/veecle/FreeRTOS-rust/target/debug/deps/libfreertos_rust-735dd7d96cfbebc4.rlib(freertos_rust-735dd7d96cfbebc4.1hbzz7lkzbkykmz4.rcgu.o): in function `freertos_rust::task::Task::spawn_inner::thread_start':
          /home/alex/git/veecle/FreeRTOS-rust/freertos-rust/src/task.rs:207: undefined reference to `freertos_rs_get_current_task'
          /usr/bin/ld: /home/alex/git/veecle/FreeRTOS-rust/freertos-rust/src/task.rs:212: undefined reference to `freertos_rs_delete_task'
          /usr/bin/ld: /home/alex/git/veecle/FreeRTOS-rust/target/debug/deps/libfreertos_rust-735dd7d96cfbebc4.rlib(freertos_rust-735dd7d96cfbebc4.1hbzz7lkzbkykmz4.rcgu.o): in function `freertos_rust::task::CurrentTask::delay':
          /home/alex/git/veecle/FreeRTOS-rust/freertos-rust/src/task.rs:339: undefined reference to `freertos_rs_vTaskDelay'
          /usr/bin/ld: /home/alex/git/veecle/FreeRTOS-rust/target/debug/deps/libfreertos_rust-735dd7d96cfbebc4.rlib(freertos_rust-735dd7d96cfbebc4.1hbzz7lkzbkykmz4.rcgu.o): in function `freertos_rust::task::FreeRtosUtils::start_scheduler':
          /home/alex/git/veecle/FreeRTOS-rust/freertos-rust/src/task.rs:438: undefined reference to `freertos_rs_vTaskStartScheduler'
          /usr/bin/ld: /home/alex/git/veecle/FreeRTOS-rust/target/debug/deps/libfreertos_rust-735dd7d96cfbebc4.rlib(freertos_rust-735dd7d96cfbebc4.2eu7905y0teijgi0.rcgu.o): in function `<freertos_rust::allocator::FreeRtosAllocator as core::alloc::global::GlobalAlloc>::alloc':
          /home/alex/git/veecle/FreeRTOS-rust/freertos-rust/src/allocator.rs:15: undefined reference to `freertos_rs_pvPortMalloc'
          /usr/bin/ld: /home/alex/git/veecle/FreeRTOS-rust/target/debug/deps/libfreertos_rust-735dd7d96cfbebc4.rlib(freertos_rust-735dd7d96cfbebc4.2eu7905y0teijgi0.rcgu.o): in function `<freertos_rust::allocator::FreeRtosAllocator as core::alloc::global::GlobalAlloc>::dealloc':
          /home/alex/git/veecle/FreeRTOS-rust/freertos-rust/src/allocator.rs:20: undefined reference to `freertos_rs_vPortFree'
          collect2: error: ld returned 1 exit status

  = note: some `extern` functions couldn't be found; some native libraries may need to be installed or have their path specified
  = note: use the `-l` flag to specify native libraries to link
  = note: use the `cargo:rustc-link-lib` directive to specify the native libraries to link with Cargo (see https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-link-lib)

error: could not compile `freertos-rust-examples` (example "linux") due to 1 previous error
```