### PR TITLE
refactor: switch from unmaintained freertos-addons to freeRTOS provided port

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "freertos-rust-examples/FreeRTOS-Kernel"]
 	path = freertos-rust-examples/FreeRTOS-Kernel
 	url = https://github.com/FreeRTOS/FreeRTOS-Kernel.git
-[submodule "freertos-rust-examples/freertos-addons"]
-	path = freertos-rust-examples/freertos-addons
-	url = https://github.com/michaelbecker/freertos-addons.git

--- a/freertos-cargo-build/src/lib.rs
+++ b/freertos-cargo-build/src/lib.rs
@@ -193,7 +193,7 @@ impl Builder {
             target_env.as_str(),
         ) {
             (_, "x86_64", "windows", _) => "MSVC-MingW",
-            (_, "x86_64", "linux", "gnu") => "GCC/Linux",
+            (_, "x86_64", "linux", "gnu") => "ThirdParty/GCC/Posix",
             ("thumbv7m-none-eabi", _, _, _) => "GCC/ARM_CM3",
             ("thumbv7em-none-eabi", _, _, _) => "GCC/ARM_CM3", // M4 cores without FPU use M3
             ("thumbv7em-none-eabihf", _, _, _) => "GCC/ARM_CM4F",

--- a/freertos-rust-examples/build.rs
+++ b/freertos-rust-examples/build.rs
@@ -30,7 +30,6 @@ fn main() {
 
     if target == "x86_64-unknown-linux-gnu" {
         b.freertos_config("examples/linux");
-        b.freertos_port_base("freertos-addons/Linux/portable");
 
         b.add_build_file("examples/linux/hooks.c");
         // b.add_build_file("examples/linux/Run-time-stats-utils.c"); // Unimplemented yet..

--- a/freertos-rust-examples/examples/linux/FreeRTOSConfig.h
+++ b/freertos-rust-examples/examples/linux/FreeRTOSConfig.h
@@ -103,11 +103,6 @@ extern "C" {
 /* Run time stats gathering configuration options. */
 unsigned long ulGetRunTimeCounterValue( void ); /* Prototype of function that returns run time counter. */
 #define configGENERATE_RUN_TIME_STATS			1
-/* Make use of times(man 2) to gather run-time statistics on the tasks. */
-extern void vPortFindTicksPerSecond( void );
-#define portCONFIGURE_TIMER_FOR_RUN_TIME_STATS() vPortFindTicksPerSecond()
-extern unsigned long ulPortGetTimerValue( void );
-#define portGET_RUN_TIME_COUNTER_VALUE() ulPortGetTimerValue()
 
 /* Co-routine related configuration options. */
 #define configUSE_CO_ROUTINES 					1


### PR DESCRIPTION
<!---
Thanks for creating a pull request!

Please start your PR title with the appropriate prefix as specified by [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#specification):

chore: [your title]
docs: [your title]
feat: [your title]
fix: [your title]
refactor: [your title]
rfc: [your title]
test: [your title]
-->


## Intent
<!---
Please describe what you want to achieve here.
Keep your PR limited to one logical change.
For example, if you add a feature, don't include fixes you made along the way
Please open another PR for more contributions.
-->

`freertos-addons` seems to be unmaintained and it is not required for the Linux example.

## Description
<!--- 
For complex PRs, please describe what you did to achieve your goal here.
Did you consider different approaches, where there any trade-offs you made?
More information about why you implemented your solution the way you did helps reviewers.
This section can be removed for obvious changes like typo fixes.
-->

This PR removes the `freertos-addons` submodule and dependency in favor of the Linux/Posix port in the FreeRTOS-Kernel repository. With the change, some configuration in the `FreeRTOSConfig.h` file got redundant and subsequently removed.

## Checklist
<!--- 
Please make sure all that apply are checked.
-->
- [na] Documentation in README, crate, module, function and/or other locations added/adapted.
- [na] New tests added and/or existing tests adapted.
- [x] PR is limited to a single logical change.
- [x] At least the first commit has a clear title and a descriptive message containing reasoning for the change. This will be included in the final commit message after squashing and merging.
